### PR TITLE
Refactor legacy ComponentsHandler and EventsHandler

### DIFF
--- a/app/src/main/java/mod/hilal/saif/components/ComponentsHandler.java
+++ b/app/src/main/java/mod/hilal/saif/components/ComponentsHandler.java
@@ -27,16 +27,12 @@ import pro.sketchware.SketchApplication;
 import pro.sketchware.model.CustomComponent;
 import pro.sketchware.utility.FileUtil;
 import pro.sketchware.utility.SketchwareUtil;
-//responsible code :
-//ComponentBean == sketchware / beans
-//Manage components == agus /component
-//Manage events components == agus/editor/event
-//TypeVarComponent == agus / lib
-//TypeClassComponent == agus/lib
-//importClass== dev.aldi.sayuti.editor.manage
 
 public class ComponentsHandler {
 
+    private static final int ASYNC_TASK_COMPONENT_ID = 36;
+    private static final String ASYNC_TASK_TYPE_NAME = "AsyncTask";
+    private static final Gson GSON = new Gson();
     private static ArrayList<CustomComponent> cachedCustomComponents = readCustomComponents();
 
     /**
@@ -45,115 +41,152 @@ public class ComponentsHandler {
     private ComponentsHandler() {
     }
 
+    private static final class ComponentMatch {
+
+        private final int index;
+        private final CustomComponent component;
+
+        private ComponentMatch(int index, CustomComponent component) {
+            this.index = index;
+            this.component = component;
+        }
+    }
+
+    private static void reportNullComponent(int index) {
+        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), index));
+    }
+
+    private static int getComponentIdOrReport(CustomComponent component, int index, int errorResId) {
+        int idVal = component.getIdAsInt();
+        if (idVal == -1) {
+            SketchwareUtil.toastError(String.format(Helper.getResString(errorResId), index + 1), Toast.LENGTH_LONG);
+        }
+        return idVal;
+    }
+
+    private static ComponentMatch findComponentById(int id) {
+        for (int i = 0; i < cachedCustomComponents.size(); i++) {
+            CustomComponent component = cachedCustomComponents.get(i);
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            if (component.getIdAsInt() == id) {
+                return new ComponentMatch(i, component);
+            }
+        }
+        return null;
+    }
+
+    private static ComponentMatch findComponentByTypeName(String typeName) {
+        for (int i = 0; i < cachedCustomComponents.size(); i++) {
+            CustomComponent component = cachedCustomComponents.get(i);
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            if (typeName.equals(component.getTypeName())) {
+                return new ComponentMatch(i, component);
+            }
+        }
+        return null;
+    }
+
+    private static ComponentMatch findComponentByName(String name) {
+        for (int i = 0; i < cachedCustomComponents.size(); i++) {
+            CustomComponent component = cachedCustomComponents.get(i);
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            if (name.equals(component.getName())) {
+                return new ComponentMatch(i, component);
+            }
+        }
+        return null;
+    }
+
+    private static ComponentMatch findComponentByVarName(String varName) {
+        for (int i = 0; i < cachedCustomComponents.size(); i++) {
+            CustomComponent component = cachedCustomComponents.get(i);
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            if (varName.equals(component.getVarName())) {
+                return new ComponentMatch(i, component);
+            }
+        }
+        return null;
+    }
+
+    private static ArrayList<CustomComponent> parseCustomComponents(String content) throws JsonSyntaxException {
+        return GSON.fromJson(content, new TypeToken<ArrayList<CustomComponent>>(){}.getType());
+    }
+
     /**
      * Called at {@link ComponentBean#getComponentTypeByTypeName(String)}.
      */
-    // give typeName and return id
     public static int getIdByTypeName(String name) {
-        if (name.equals("AsyncTask")) {
-            return 36;
+        if (name.equals(ASYNC_TASK_TYPE_NAME)) {
+            return ASYNC_TASK_COMPONENT_ID;
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (name.equals(component.getTypeName())) {
-                    int idVal = component.getIdAsInt();
-                    if (idVal != -1) {
-                        return idVal;
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_invalid_id_in), i + 1), Toast.LENGTH_LONG);
-                        break;
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
+        ComponentMatch match = findComponentByTypeName(name);
+        if (match == null) {
+            return -1;
         }
-
-        return -1;
+        int idVal = getComponentIdOrReport(match.component, match.index, R.string.component_error_invalid_id_in);
+        return idVal != -1 ? idVal : -1;
     }
 
     /**
      * Called at {@link ComponentBean#getComponentTypeName(int)}.
      */
-    // give id and return typeName
     public static String getTypeNameById(int id) {
-        if (id == 36) {
-            return "AsyncTask";
+        if (id == ASYNC_TASK_COMPONENT_ID) {
+            return ASYNC_TASK_TYPE_NAME;
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    return component.getTypeName();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i), Toast.LENGTH_LONG);
-            }
-        }
-
-        return "";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getTypeName() : "";
     }
 
     /**
      * Called at {@link ComponentBean#getComponentName(Context, int)}.
      */
-    // give id and return name
     public static String getNameById(int id) {
-        if (id == 36) {
-            return "AsyncTask";
+        if (id == ASYNC_TASK_COMPONENT_ID) {
+            return ASYNC_TASK_TYPE_NAME;
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    return component.getName();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
-        }
-        return "component";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getName() : "component";
     }
 
     /**
      * Called at {@link ComponentBean#getIconResource(int)}.
      */
-    // give id and return icon
     public static int getIconById(int id) {
-        if (id == 36) {
+        if (id == ASYNC_TASK_COMPONENT_ID) {
             return R.drawable.ic_cycle_color_48dp;
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    try {
-                        return OldResourceIdMapper.getDrawableFromOldResourceId(Integer.parseInt(component.getIcon()));
-                    } catch (NumberFormatException e) {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_invalid_icon), i + 1), Toast.LENGTH_LONG);
-                        break;
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
+        ComponentMatch match = findComponentById(id);
+        if (match == null) {
+            return R.drawable.color_new_96;
         }
-
-        return R.drawable.color_new_96;
+        try {
+            return OldResourceIdMapper.getDrawableFromOldResourceId(Integer.parseInt(match.component.getIcon()));
+        } catch (NumberFormatException e) {
+            SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_invalid_icon), match.index + 1), Toast.LENGTH_LONG);
+            return R.drawable.color_new_96;
+        }
     }
 
     /**
      * @return Descriptions of Components, both built-in ones and Custom Components'
      */
-    // give id and return description
-    //goto ComponentAddActivity
-    //remove lines: 2303 to 2307
-    //call this method using v0 as id and move result to v0
     public static String getDescription(int id) {
         int componentBeanDescriptionResId = ComponentBean.getDescStrResource(id);
         if (componentBeanDescriptionResId != 0) {
@@ -167,106 +200,61 @@ public class ComponentsHandler {
      * @return Component description of a Custom Component
      */
     public static String getCustomDescription(int id) {
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    return component.getDescription();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
-        }
-
-        return "new component";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getDescription() : "new component";
     }
 
     /**
      * Called at {@link ComponentBean#getComponentDocsUrlByTypeName(int)}.
      */
-    // give id and return docs url
     public static String getDocsUrlById(int id) {
-        if (id != 36) {
-            for (int i = 0; i < cachedCustomComponents.size(); i++) {
-                CustomComponent component = cachedCustomComponents.get(i);
-                if (component != null) {
-                    if (component.getIdAsInt() == id) {
-                        return component.getUrl();
-                    }
-                } else {
-                    SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-                }
-            }
+        if (id == ASYNC_TASK_COMPONENT_ID) {
+            return "";
         }
 
-        return "";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getUrl() : "";
     }
 
     /**
      * Called at {@link ComponentBean#buildClassInfo()}.
      */
     public static String getBuildClassById(int id) {
-        if (id == 36) {
-            return "AsyncTask";
+        if (id == ASYNC_TASK_COMPONENT_ID) {
+            return ASYNC_TASK_TYPE_NAME;
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    return component.getBuildClass();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
-        }
-
-        return "";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getBuildClass() : "";
     }
-
-    // mod section
 
     /**
      * Adds Custom Components to available Components section.
      * Used at {@link com.besome.sketch.editor.component.AddComponentBottomSheet#onCreate(Bundle)}.
      */
-    // add components to sk
-    //structure : list.add(new ComponentBean(27));
     public static void addCustomComponents(ArrayList<ComponentBean> list) {
-        list.add(new ComponentBean(36));
+        list.add(new ComponentBean(ASYNC_TASK_COMPONENT_ID));
 
         for (int i = 0; i < cachedCustomComponents.size(); i++) {
             CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                int idVal = component.getIdAsInt();
-                if (idVal != -1) {
-                    list.add(new ComponentBean(idVal));
-                } else {
-                    SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_invalid_id_for), i + 1), Toast.LENGTH_LONG);
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            int idVal = getComponentIdOrReport(component, i, R.string.component_error_invalid_id_for);
+            if (idVal != -1) {
+                list.add(new ComponentBean(idVal));
             }
         }
     }
 
     public static String getVarNameById(int id) {
-        if (id == 36) {
+        if (id == ASYNC_TASK_COMPONENT_ID) {
             return "#";
         }
 
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (component.getIdAsInt() == id) {
-                    return component.getVarName();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
-        }
-
-        return "";
+        ComponentMatch match = findComponentById(id);
+        return match != null ? match.component.getVarName() : "";
     }
 
     /**
@@ -275,22 +263,12 @@ public class ComponentsHandler {
      */
     @NonNull
     public static String getClassByTypeName(@NonNull String name) {
-        if (name.equals("AsyncTask")) {
+        if (name.equals(ASYNC_TASK_TYPE_NAME)) {
             return "Component.AsyncTask";
         }
 
-        for (int i = 0, customComponentsSize = cachedCustomComponents.size(); i < customComponentsSize; i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (name.equals(component.getTypeName())) {
-                    return component.getClassName();
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
-        }
-
-        return "Component";
+        ComponentMatch match = findComponentByTypeName(name);
+        return match != null ? match.component.getClassName() : "Component";
     }
 
     /**
@@ -298,58 +276,35 @@ public class ComponentsHandler {
      * to get Custom Components' fields.
      */
     public static String getExtraVar(String name, String code, String varName) {
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (name.equals(component.getName())) {
-                    String additionalVar = component.getAdditionalVar();
-                    if (TextUtils.isEmpty(additionalVar)) {
-                        return code;
-                    } else {
-                        return code + "\r\n" + additionalVar.replace("###", varName);
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
+        ComponentMatch match = findComponentByName(name);
+        if (match == null) {
+            return code;
         }
-
-        return code;
+        String additionalVar = match.component.getAdditionalVar();
+        return TextUtils.isEmpty(additionalVar) ? code : code + "\r\n" + additionalVar.replace("###", varName);
     }
 
-    // define extra variable
     public static String getDefineExtraVar(String name, String varName) {
-        for (int i = 0; i < cachedCustomComponents.size(); i++) {
-            CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (name.equals(component.getName())) {
-                    String defineAdditionalVar = component.getDefineAdditionalVar();
-                    if (TextUtils.isEmpty(defineAdditionalVar)) {
-                        break;
-                    } else {
-                        return defineAdditionalVar.replace("###", varName);
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
-            }
+        ComponentMatch match = findComponentByName(name);
+        if (match == null) {
+            return "";
         }
-
-        return "";
+        String defineAdditionalVar = match.component.getDefineAdditionalVar();
+        return TextUtils.isEmpty(defineAdditionalVar) ? "" : defineAdditionalVar.replace("###", varName);
     }
 
     public static void getImports(String name, ArrayList<String> arrayList) {
         for (int i = 0; i < cachedCustomComponents.size(); i++) {
             CustomComponent component = cachedCustomComponents.get(i);
-            if (component != null) {
-                if (name.equals(component.getVarName())) {
-                    String imports = component.getImports();
-                    if (!imports.isEmpty()) {
-                        arrayList.addAll(Arrays.asList(imports.split("\n")));
-                    }
+            if (component == null) {
+                reportNullComponent(i);
+                continue;
+            }
+            if (name.equals(component.getVarName())) {
+                String imports = component.getImports();
+                if (!imports.isEmpty()) {
+                    arrayList.addAll(Arrays.asList(imports.split("\n")));
                 }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_null), i));
             }
         }
     }
@@ -365,9 +320,9 @@ public class ComponentsHandler {
     private static ArrayList<CustomComponent> readCustomComponents() {
         ArrayList<CustomComponent> data;
         if (FileUtil.isExistFile(getPath())) {
+            String content = FileUtil.readFile(getPath());
             try {
-                data = new Gson().fromJson(FileUtil.readFile(getPath()),
-                        new TypeToken<ArrayList<CustomComponent>>(){}.getType());
+                data = parseCustomComponents(content);
             } catch (JsonSyntaxException e) {
                 data = new ArrayList<>();
                 SketchwareUtil.toastError(String.format(Helper.getResString(R.string.component_error_read_failed), e.getMessage()));
@@ -416,8 +371,7 @@ public class ComponentsHandler {
 
         List<CustomComponent> components;
         try {
-            components = new Gson().fromJson(content,
-                    new TypeToken<ArrayList<CustomComponent>>(){}.getType());
+            components = parseCustomComponents(content);
         } catch (JsonSyntaxException e) {
             return new Pair<>(Optional.of(Helper.getResString(R.string.publish_message_dialog_invalid_json)), Collections.emptyList());
         }

--- a/app/src/main/java/mod/hilal/saif/events/EventsHandler.java
+++ b/app/src/main/java/mod/hilal/saif/events/EventsHandler.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -21,8 +22,12 @@ import pro.sketchware.utility.SketchwareUtil;
 
 public class EventsHandler {
 
+    private static final String TAG = "EventsHandler";
+    private static final Gson GSON = new Gson();
+
     public static final String CUSTOM_EVENTS_FILE_PATH = SketchwarePaths.getAbsolutePathOf(SketchwarePaths.CUSTOM_EVENTS_FILE);
     public static final String CUSTOM_LISTENER_FILE_PATH = SketchwarePaths.getAbsolutePathOf(SketchwarePaths.CUSTOM_LISTENERS_FILE);
+
     private static ArrayList<CustomEvent> cachedCustomEvents = readCustomEvents();
     private static ArrayList<CustomListener> cachedCustomListeners = readCustomListeners();
 
@@ -30,6 +35,135 @@ public class EventsHandler {
      * This is a utility class, don't instantiate it.
      */
     private EventsHandler() {
+    }
+
+    private static final class EventMatch {
+
+        private final int index;
+        private final CustomEvent event;
+
+        private EventMatch(int index, CustomEvent event) {
+            this.index = index;
+            this.event = event;
+        }
+    }
+
+    private static final class ListenerMatch {
+
+        private final int index;
+        private final CustomListener listener;
+
+        private ListenerMatch(int index, CustomListener listener) {
+            this.index = index;
+            this.listener = listener;
+        }
+    }
+
+    private static void reportNullCustomEvent(int index) {
+        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), index));
+    }
+
+    private static void reportNullCustomListener(int index) {
+        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), index));
+    }
+
+    private static EventMatch findCustomEventByName(String name) {
+        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
+            CustomEvent customEvent = cachedCustomEvents.get(i);
+            if (customEvent == null) {
+                reportNullCustomEvent(i);
+                continue;
+            }
+            if (name.equals(customEvent.getName())) {
+                return new EventMatch(i, customEvent);
+            }
+        }
+        return null;
+    }
+
+    private static ListenerMatch findCustomListenerByName(String name) {
+        for (int i = 0, cachedCustomListenersSize = cachedCustomListeners.size(); i < cachedCustomListenersSize; i++) {
+            CustomListener customListener = cachedCustomListeners.get(i);
+            if (customListener == null) {
+                reportNullCustomListener(i);
+                continue;
+            }
+            if (name.equals(customListener.getName())) {
+                return new ListenerMatch(i, customListener);
+            }
+        }
+        return null;
+    }
+
+    private static void addCustomEventsForType(ClassInfo classInfo, ArrayList<String> list) {
+        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
+            CustomEvent customEvent = cachedCustomEvents.get(i);
+            if (customEvent == null) {
+                reportNullCustomEvent(i);
+                continue;
+            }
+            if (classInfo.matchesType(customEvent.getVar())) {
+                list.add(customEvent.getName());
+            }
+        }
+    }
+
+    private static void addCustomListenersForType(ClassInfo classInfo, ArrayList<String> list) {
+        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
+            CustomEvent customEvent = cachedCustomEvents.get(i);
+            if (customEvent == null) {
+                reportNullCustomEvent(i);
+                continue;
+            }
+            if (classInfo.matchesType(customEvent.getVar())) {
+                String listener = customEvent.getListener();
+                if (!list.contains(listener)) {
+                    list.add(listener);
+                }
+            }
+        }
+    }
+
+    private static void addCustomEventsForListener(String listenerName, ArrayList<String> list) {
+        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
+            CustomEvent customEvent = cachedCustomEvents.get(i);
+            if (customEvent == null) {
+                reportNullCustomEvent(i);
+                continue;
+            }
+            if (listenerName.equals(customEvent.getListener())) {
+                list.add(customEvent.getName());
+            }
+        }
+    }
+
+    private static void addImports(ArrayList<String> list, String imports) {
+        if (!imports.isEmpty()) {
+            list.addAll(new ArrayList<>(Arrays.asList(imports.split("\n"))));
+        }
+    }
+
+    private static <T> ArrayList<T> readCustomConfig(String filePath, Type listType, String configLabel) {
+        if (!FileUtil.isExistFile(filePath)) {
+            return new ArrayList<>();
+        }
+
+        String content = FileUtil.readFile(filePath);
+        if (content.isEmpty() || content.equals("[]")) {
+            return new ArrayList<>();
+        }
+
+        try {
+            ArrayList<T> data = GSON.fromJson(content, listType);
+            if (data == null) {
+                LogUtil.e(TAG, "Failed to parse " + configLabel + " file! Now using none");
+                return new ArrayList<>();
+            }
+            return data;
+        } catch (JsonParseException e) {
+            LogUtil.e(TAG, "Failed to parse " + configLabel + " file! Now using none", e);
+            return new ArrayList<>();
+        }
     }
 
     /**
@@ -62,12 +196,12 @@ public class EventsHandler {
 
         for (int i = cachedCustomEvents.size() - 1; i >= 0; i--) {
             CustomEvent customEvent = cachedCustomEvents.get(i);
-            if (customEvent != null) {
-                if (customEvent.getVar().isEmpty()) {
-                    array.add(customEvent.getName());
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
+            if (customEvent == null) {
+                reportNullCustomEvent(i);
+                continue;
+            }
+            if (customEvent.getVar().isEmpty()) {
+                array.add(customEvent.getName());
             }
         }
 
@@ -92,16 +226,7 @@ public class EventsHandler {
             list.add("onPostExecute");
         }
 
-        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-            CustomEvent customEvent = cachedCustomEvents.get(i);
-            if (customEvent != null) {
-                if (gx.matchesType(customEvent.getVar())) {
-                    list.add(customEvent.getName());
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-            }
-        }
+        addCustomEventsForType(gx, list);
     }
 
     /**
@@ -119,19 +244,7 @@ public class EventsHandler {
             list.add("AsyncTaskClass");
         }
 
-        for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-            CustomEvent customEvent = cachedCustomEvents.get(i);
-            if (customEvent != null) {
-                if (gx.matchesType(customEvent.getVar())) {
-                    String listener = customEvent.getListener();
-                    if (!list.contains(listener)) {
-                        list.add(listener);
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-            }
-        }
+        addCustomListenersForType(gx, list);
     }
 
     /**
@@ -156,16 +269,7 @@ public class EventsHandler {
                 break;
 
             default:
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (name.equals(customEvent.getListener())) {
-                            list.add(customEvent.getName());
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
+                addCustomEventsForListener(name, list);
                 break;
         }
     }
@@ -182,23 +286,16 @@ public class EventsHandler {
             case "onProgressUpdate" -> R.drawable.ic_mtrl_progress;
             case "onPostExecute" -> R.drawable.ic_mtrl_progress_check;
             default -> {
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (name.equals(customEvent.getName())) {
-                            try {
-                                yield OldResourceIdMapper.getDrawableFromOldResourceId(Integer.parseInt(customEvent.getIcon()));
-                            } catch (NumberFormatException e) {
-                                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_invalid_icon), i + 1));
-                                yield R.drawable.android_icon;
-                            }
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
+                EventMatch match = findCustomEventByName(name);
+                if (match == null) {
+                    yield R.drawable.android_icon;
                 }
-
-                yield R.drawable.android_icon;
+                try {
+                    yield OldResourceIdMapper.getDrawableFromOldResourceId(Integer.parseInt(match.event.getIcon()));
+                } catch (NumberFormatException e) {
+                    SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_invalid_icon), match.index + 1));
+                    yield R.drawable.android_icon;
+                }
             }
         };
     }
@@ -220,18 +317,8 @@ public class EventsHandler {
             case "onPostExecute" ->
                     Helper.getResString(R.string.event_desc_post_execute);
             default -> {
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (name.equals(customEvent.getName())) {
-                            yield customEvent.getDescription();
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
-
-                yield "No_Description";
+                EventMatch match = findCustomEventByName(name);
+                yield match != null ? match.event.getDescription() : "No_Description";
             }
         };
     }
@@ -239,26 +326,22 @@ public class EventsHandler {
     public static String getEventCode(String targetId, String name, String param) {
         return switch (name) {
             case "Import" ->
-                // Changed from: "...vF\n${param}\n//3b..."
                     "//Ul5kmZqmO867OV0QTGOpjwX7MXmgzxzQBSZTf0Y16PnDXkhLsZfvF\r\n" +
                             param + "\r\n" +
                             "//3b5IqsVG57gNqLi7FBO2MeOW6iI7tOustUGwcA7HKXm0o7lovZ";
             case "onActivityResult", "initializeLogic" -> "";
             case "onSwipeRefreshLayout" ->
-                // Changed from: "@Override \npublic void..."
                     "@Override\r\n" +
                             "public void onRefresh() {\n" +
                             param + "\r\n" +
                             "}";
             case " onLongClick" ->
-                // Changed from: "@Override\r\n public boolean..."
                     "@Override\r\n" +
                             "public boolean onLongClick(View _view) {\r\n" +
                             param + "\r\n" +
                             "return true;\r\n" +
                             "}";
             case "onTabLayoutNewTabAdded" ->
-                // Changed from: "public  CharSequence  onTabLayoutNewTabAdded( int   _position ){..."
                     "public CharSequence onTabLayoutNewTabAdded(int _position) {\r\n" +
                             (param.isEmpty() ? "return \"\";\r\n" :
                                     param + "\r\n"
@@ -282,18 +365,8 @@ public class EventsHandler {
                     param + "\r\n" +
                     "}";
             default -> {
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (name.equals(customEvent.getName())) {
-                            yield String.format(customEvent.getCode().replace("###", targetId), param);
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
-
-                yield "//no code";
+                EventMatch match = findCustomEventByName(name);
+                yield match != null ? String.format(match.event.getCode().replace("###", targetId), param) : "//no code";
             }
         };
     }
@@ -306,18 +379,8 @@ public class EventsHandler {
             case "onTabLayoutNewTabAdded", "onProgressUpdate" -> "%d";
             case "doInBackground", "onPostExecute" -> "%s";
             default -> {
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (name.equals(customEvent.getName())) {
-                            yield customEvent.getParameters();
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
-
-                yield "";
+                EventMatch match = findCustomEventByName(name);
+                yield match != null ? match.event.getParameters() : "";
             }
         };
     }
@@ -336,23 +399,12 @@ public class EventsHandler {
             case "onProgressUpdate" -> name + " onProgressUpdate progress %d.value";
             case "onPostExecute" -> name + " onPostExecute result %s.result";
             default -> {
-                for (int i = 0, cachedCustomEventsSize = cachedCustomEvents.size(); i < cachedCustomEventsSize; i++) {
-                    CustomEvent customEvent = cachedCustomEvents.get(i);
-                    if (customEvent != null) {
-                        if (event.equals(customEvent.getName())) {
-                            yield customEvent.getHeaderSpec().replace("###", name);
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
-
-                yield "no spec";
+                EventMatch match = findCustomEventByName(event);
+                yield match != null ? match.event.getHeaderSpec().replace("###", name) : "no spec";
             }
         };
     }
 
-    /// listeners codes
     public static String getListenerCode(String name, String var, String param) {
         return switch (name) {
             case " onLongClickListener" ->
@@ -368,18 +420,8 @@ public class EventsHandler {
                             param + "\r\n" +
                             "}";
             default -> {
-                for (int i = 0, cachedCustomListenersSize = cachedCustomListeners.size(); i < cachedCustomListenersSize; i++) {
-                    CustomListener customListener = cachedCustomListeners.get(i);
-                    if (customListener != null) {
-                        if (name.equals(customListener.getName())) {
-                            yield String.format(customListener.getCode().replace("###", var), param);
-                        }
-                    } else {
-                        SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
-                    }
-                }
-
-                yield "//no listener code";
+                ListenerMatch match = findCustomListenerByName(name);
+                yield match != null ? String.format(match.listener.getCode().replace("###", var), param) : "//no listener code";
             }
         };
     }
@@ -387,15 +429,12 @@ public class EventsHandler {
     public static void getImports(ArrayList<String> list, String name) {
         for (int i = 0, cachedCustomListenersSize = cachedCustomListeners.size(); i < cachedCustomListenersSize; i++) {
             CustomListener customListener = cachedCustomListeners.get(i);
-            if (customListener != null) {
-                if (name.equals(customListener.getName())) {
-                    String imports = customListener.getImports();
-                    if (!imports.isEmpty()) {
-                        list.addAll(new ArrayList<>(Arrays.asList(imports.split("\n"))));
-                    }
-                }
-            } else {
-                SketchwareUtil.toastError(String.format(Helper.getResString(R.string.event_error_null), i));
+            if (customListener == null) {
+                reportNullCustomListener(i);
+                continue;
+            }
+            if (name.equals(customListener.getName())) {
+                addImports(list, customListener.getImports());
             }
         }
     }
@@ -409,50 +448,18 @@ public class EventsHandler {
     }
 
     private static ArrayList<CustomEvent> readCustomEvents() {
-        ArrayList<CustomEvent> customEvents = new ArrayList<>();
-
-        if (FileUtil.isExistFile(CUSTOM_EVENTS_FILE_PATH)) {
-            String customEventsContent = FileUtil.readFile(CUSTOM_EVENTS_FILE_PATH);
-
-            if (!customEventsContent.isEmpty() && !customEventsContent.equals("[]")) {
-                try {
-                    customEvents = new Gson().fromJson(customEventsContent,
-                            new TypeToken<ArrayList<CustomEvent>>(){}.getType());
-
-                    if (customEvents == null) {
-                        LogUtil.e("EventsHandler", "Failed to parse Custom Events file! Now using none");
-                        customEvents = new ArrayList<>();
-                    }
-                } catch (JsonParseException e) {
-                    LogUtil.e("EventsHandler", "Failed to parse Custom Events file! Now using none", e);
-                }
-            }
-        }
-
-        return customEvents;
+        return readCustomConfig(
+                CUSTOM_EVENTS_FILE_PATH,
+                new TypeToken<ArrayList<CustomEvent>>(){}.getType(),
+                "Custom Events"
+        );
     }
 
     private static ArrayList<CustomListener> readCustomListeners() {
-        ArrayList<CustomListener> customListeners = new ArrayList<>();
-
-        if (FileUtil.isExistFile(CUSTOM_LISTENER_FILE_PATH)) {
-            String customListenersContent = FileUtil.readFile(CUSTOM_LISTENER_FILE_PATH);
-
-            if (!customListenersContent.isEmpty() && !customListenersContent.equals("[]")) {
-                try {
-                    customListeners = new Gson().fromJson(customListenersContent,
-                            new TypeToken<ArrayList<CustomListener>>(){}.getType());
-
-                    if (customListeners == null) {
-                        LogUtil.e("EventsHandler", "Failed to parse Custom Listeners file! Now using none");
-                        customListeners = new ArrayList<>();
-                    }
-                } catch (JsonParseException e) {
-                    LogUtil.e("EventsHandler", "Failed to parse Custom Listeners file! Now using none", e);
-                }
-            }
-        }
-
-        return customListeners;
+        return readCustomConfig(
+                CUSTOM_LISTENER_FILE_PATH,
+                new TypeToken<ArrayList<CustomListener>>(){}.getType(),
+                "Custom Listeners"
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR completes the refactor requested in #1 for the legacy handler code.

### ComponentsHandler
- centralizes repeated custom component lookup logic
- consolidates repeated null/error handling
- reuses a shared Gson parser for component config loading
- removes obsolete patch-style comments
- preserves public API behavior

### EventsHandler
- centralizes repeated custom event/listener lookup logic
- extracts shared config loading into `readCustomConfig(...)`
- reduces repeated null/error branches
- removes obsolete patch-history comments
- preserves public API behavior

### Compatibility fix
- restores `ComponentsHandler.getImports()` to accumulate imports from all matching custom components
- avoids the regression where only the first matching component was used

## Verification

- `.\gradlew.bat :app:compileDebugJavaWithJavac`
- `.\gradlew.bat :app:assembleDebug`
- installed debug build on device successfully
- ran focused regression validation for `ComponentsHandler.getImports()`
- performed additional regression review for `EventsHandler`

## Notes

- no public API changes intended
- behavior compatibility preserved for existing custom component/event/listener flows

Closes #1