### PR TITLE
Harden command block temp state handling and malformed block parsing

### DIFF
--- a/app/src/main/java/mod/hilal/saif/blocks/CommandBlock.java
+++ b/app/src/main/java/mod/hilal/saif/blocks/CommandBlock.java
@@ -4,8 +4,6 @@ import android.util.Pair;
 
 import com.google.gson.Gson;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -13,6 +11,7 @@ import java.util.regex.PatternSyntaxException;
 
 import mod.hey.studios.util.Helper;
 import mod.jbk.util.LogUtil;
+import pro.sketchware.core.SketchwarePaths;
 import pro.sketchware.utility.FileUtil;
 
 /**
@@ -30,8 +29,7 @@ import pro.sketchware.utility.FileUtil;
 public class CommandBlock {
 
     private static final String TAG = "CommandBlock";
-    private static final String TEMP_COMMANDS_PATH = FileUtil.getExternalStorageDir().concat("/.sketchware/temp/commands");
-    private static final String TEMP_LOG_PATH = FileUtil.getExternalStorageDir().concat("/.sketchware/temp/log.txt");
+    private static final String TEMP_COMMANDS_PATH = SketchwarePaths.getTempCommandsPath();
     private static final String JAVA_COMMAND_START_MARKER = "/*-JX4UA2y_f1OckjjvxWI.bQwRei-sLEsBmds7ArsRfi0xSFEP3Php97kjdMCs5ed";
     private static final String JAVA_COMMAND_END_MARKER = "BpWI8U4flOpx8Ke66QTlZYBA_NEusQ7BN-D0wvZs7ArsRfi0.EP3Php97kjdMCs*/";
     private static final String XML_COMMAND_START_MARKER = "/*AXAVajPNTpbJjsz-NGVTp08YDzfI-04kA7ZsuCl4GHqTQQiuWL45sV6Vf4gwK";
@@ -42,6 +40,12 @@ public class CommandBlock {
     private static final String KEY_BEFORE = "before";
     private static final String KEY_COMMAND = "command";
     private static final String KEY_INPUT = "input";
+    private static final String COMMAND_FIND_REPLACE = "find-replace";
+    private static final String COMMAND_FIND_REPLACE_FIRST = "find-replace-first";
+    private static final String COMMAND_FIND_REPLACE_ALL = "find-replace-all";
+    private static final String COMMAND_INSERT = "insert";
+    private static final String COMMAND_ADD = "add";
+    private static final String COMMAND_REPLACE = "replace";
     private static final Gson GSON = new Gson();
 
     public static String applyCommands(String fileName, String sourceCode) {
@@ -52,10 +56,20 @@ public class CommandBlock {
         }
         for (HashMap<String, Object> commandEntry : commandData) {
             if (fileName.equals(getInputName(getStringValue(commandEntry, KEY_INPUT)))) {
-                result = applyStoredCommand(result, commandEntry);
+                String previousResult = result;
+                try {
+                    result = applyStoredCommand(result, commandEntry);
+                } catch (RuntimeException e) {
+                    LogUtil.e(TAG, "Failed to apply stored command", e);
+                    result = previousResult;
+                }
             }
         }
         return result;
+    }
+
+    public static boolean hasTempCommands() {
+        return !readStoredCommands().isEmpty();
     }
 
     private static ArrayList<HashMap<String, Object>> readStoredCommands() {
@@ -79,7 +93,7 @@ public class CommandBlock {
     }
 
     private static String applyStoredCommand(String sourceCode, HashMap<String, Object> commandDefinition) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         String reference = getStringValue(commandDefinition, KEY_REFERENCE);
         int distance = getNumericValue(commandDefinition, KEY_DISTANCE);
         int after = getNumericValue(commandDefinition, KEY_AFTER);
@@ -87,25 +101,12 @@ public class CommandBlock {
         String command = getStringValue(commandDefinition, KEY_COMMAND);
         String input = getExceptFirstLine(getStringValue(commandDefinition, KEY_INPUT));
 
-        if (command.equals("find-replace")) {
-            return sourceCode.replace(reference, input);
-        }
-        if (command.equals("find-replace-first")) {
-            try {
-                return sourceCode.replaceFirst(reference, input);
-            } catch (PatternSyntaxException e) {
-                LogUtil.e(TAG, "Failed to apply replaceFirst command", e);
-                return sourceCode;
-            }
+        if (reference.isEmpty()) {
+            return sourceCode;
         }
 
-        if (command.equals("find-replace-all")) {
-            try {
-                return sourceCode.replaceAll(reference, input);
-            } catch (PatternSyntaxException e) {
-                LogUtil.e(TAG, "Failed to apply replaceAll command", e);
-                return sourceCode;
-            }
+        if (isTextReplacementCommand(command)) {
+            return applyTextReplacementCommand(sourceCode, command, reference, input);
         }
 
         int index = getIndex(lines, reference);
@@ -113,97 +114,15 @@ public class CommandBlock {
             return sourceCode;
         }
 
-        if (command.equals("insert")) {
-            if ((index + distance - before) < 0) {
-                lines.add(0, input);
-            } else if ((index + distance - before) > (lines.size() - 1)) {
-                lines.add(input);
-            } else {
-                lines.add(index + distance - before, input);
-            }
+        if (COMMAND_INSERT.equals(command)) {
+            addLine(lines, index + distance - before, input);
         }
-        if (command.equals("add")) {
-            if ((index + distance + after + 1) < 0) {
-                lines.add(0, input);
-            } else if ((index + distance + after + 1) > (lines.size() - 1)) {
-                lines.add(input);
-            } else {
-                lines.add(index + distance + after + 1, input);
-            }
+        if (COMMAND_ADD.equals(command)) {
+            addLine(lines, index + distance + after + 1, input);
         }
 
-        //old method
-        /*
-        if(command.equals("replace")){
-            int xxx = (int)(index + distance - before -1);
-            if ( xxx <0 ){ xxx = 0; }
-
-            int ff = (int)(index + distance - before);
-            if ( ff <0 ){ ff = 0; }
-            int tt = (int)(index + distance + after +1);
-            if ( tt > a.size() ){ tt = a.size(); }
-            a.subList(ff , tt).clear();
-
-            if (xxx > a.size()-2){
-                a.add(input);
-            } else {
-                a.add((int)(xxx+1) , input);
-            }
-        }
-        */
-
-        if (command.equals("replace")) {
-            if (before == 0 && after == 0) {
-                int lineToChange = index + distance;
-                if (lineToChange < 0) {
-                    lineToChange = 0;
-                }
-                if (lineToChange > (lines.size() - 1)) {
-                    lineToChange = lines.size() - 1;
-                }
-                lines.set(lineToChange, input);
-            } else {
-                int lineToChange = index + distance;
-                if (lineToChange <= 0) { // ignore backend
-                    lineToChange = 0;
-                    int from = 1;
-                    int to = after + 1;
-                    if (to > (lines.size() - 1)) {
-                        to = lines.size() - 1;
-                    }
-                    lines.subList(from, to).clear();
-                    lines.set(0, input);
-                } else if (lineToChange >= (lines.size() - 1)) { //ignore frontend
-                    lineToChange = lines.size() - 1;
-                    int from = lineToChange - before;
-                    int to = lineToChange;
-                    if (from < 0) {
-                        from = 0;
-                    }
-                    lines.set(lineToChange, input);
-                    lines.subList(from, to).clear();
-                } else {  //handle everything
-                    if (before < 0) {
-                        before = 0;
-                    }
-                    if (after < 0) {
-                        after = 0;
-                    }
-                    int from = lineToChange + 1;
-                    int to = lineToChange + after;
-                    if (to > (lines.size() - 1)) {
-                        to = lines.size() - 1;
-                    }
-                    lines.subList(from, to).clear();
-                    lines.set(lineToChange, input);
-                    from = lineToChange - before;
-                    to = lineToChange;
-                    if (from < 0) {
-                        from = 0;
-                    }
-                    lines.subList(from, to).clear();
-                }
-            }
+        if (COMMAND_REPLACE.equals(command)) {
+            applyReplaceCommand(lines, index, distance, before, after, input);
         }
 
         return joinLines(lines);
@@ -220,7 +139,7 @@ public class CommandBlock {
     }
 
     public static String getExceptFirstLine(String sourceCode) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         if (!lines.isEmpty()) {
             lines.remove(0);
         } else {
@@ -230,7 +149,7 @@ public class CommandBlock {
     }
 
     private static String getFirstLine(String sourceCode) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         if (!lines.isEmpty()) {
             return lines.get(0);
         } else {
@@ -260,13 +179,15 @@ public class CommandBlock {
             return RC;
         } catch (RuntimeException e) {
             LogUtil.e(TAG, "Failed to collect XML command blocks", e);
-            writeLog("Failed to collect XML command blocks", e);
             return removeCommandBlocks(sourceCode, XML_COMMAND_START_MARKER, XML_COMMAND_END_MARKER);
         }
     }
 
     // Write Temporary File
     private static void appendCommandsToTempFile(ArrayList<HashMap<String, Object>> list) {
+        if (list.isEmpty()) {
+            return;
+        }
         ArrayList<HashMap<String, Object>> data = readStoredCommands();
         data.addAll(list);
         FileUtil.writeFile(TEMP_COMMANDS_PATH, GSON.toJson(data));
@@ -294,43 +215,161 @@ public class CommandBlock {
             return RC;
         } catch (RuntimeException e) {
             LogUtil.e(TAG, "Failed to apply command blocks", e);
-            writeLog("Failed to apply command blocks", e);
-            return removeCommandBlocks(sourceCode, JAVA_COMMAND_START_MARKER, JAVA_COMMAND_END_MARKER);
+            String sanitizedSource = removeCommandBlocks(sourceCode, JAVA_COMMAND_START_MARKER, JAVA_COMMAND_END_MARKER);
+            return removeCommandBlocks(sanitizedSource, XML_COMMAND_START_MARKER, XML_COMMAND_END_MARKER);
         }
-    }
-
-    private static void writeLog(String message, Throwable throwable) {
-        String text = "";
-        if (FileUtil.isExistFile(TEMP_LOG_PATH)) {
-            text = FileUtil.readFile(TEMP_LOG_PATH);
-        }
-        StringBuilder logEntry = new StringBuilder();
-        logEntry.append("\n=>").append(message);
-        if (throwable != null) {
-            StringWriter stringWriter = new StringWriter();
-            PrintWriter printWriter = new PrintWriter(stringWriter);
-            throwable.printStackTrace(printWriter);
-            printWriter.flush();
-            logEntry.append("\n").append(stringWriter);
-        }
-        FileUtil.writeFile(TEMP_LOG_PATH, text.concat(logEntry.toString()));
     }
 
     private static void collectCommandBlocks(ArrayList<HashMap<String, Object>> commandDefinitions, String sourceCode, String startMarker, String endMarker) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         boolean isInsideCommandBlock = false;
         int startIndex = -1;
         for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
             if (isInsideCommandBlock) {
-                if (lines.get(i).contains(endMarker)) {
+                if (line.contains(startMarker)) {
+                    logDiscardedCommandBlock(startIndex);
+                    startIndex = i;
+                    if (line.contains(endMarker)) {
+                        Pair<Integer, Integer> blockRange = new Pair<>(startIndex, i);
+                        tryAddCommandDefinition(lines, commandDefinitions, blockRange);
+                        isInsideCommandBlock = false;
+                        startIndex = -1;
+                    }
+                    continue;
+                }
+                if (line.contains(endMarker)) {
                     Pair<Integer, Integer> blockRange = new Pair<>(startIndex, i);
-                    addCommandDefinition(lines, commandDefinitions, blockRange);
+                    tryAddCommandDefinition(lines, commandDefinitions, blockRange);
                     isInsideCommandBlock = false;
                     startIndex = -1;
                 }
-            } else if (lines.get(i).contains(startMarker)) {
+            } else if (line.contains(startMarker)) {
                 startIndex = i;
-                isInsideCommandBlock = true;
+                if (line.contains(endMarker)) {
+                    Pair<Integer, Integer> blockRange = new Pair<>(startIndex, i);
+                    tryAddCommandDefinition(lines, commandDefinitions, blockRange);
+                    startIndex = -1;
+                } else {
+                    isInsideCommandBlock = true;
+                }
+            }
+        }
+        if (isInsideCommandBlock) {
+            logDiscardedCommandBlock(startIndex);
+        }
+    }
+
+    private static void logDiscardedCommandBlock(int startIndex) {
+        if (startIndex >= 0) {
+            LogUtil.e(TAG, "Discarding unterminated command block starting at line " + (startIndex + 1));
+        }
+    }
+
+    private static void tryAddCommandDefinition(ArrayList<String> lines, ArrayList<HashMap<String, Object>> commandDefinitions, Pair<Integer, Integer> blockRange) {
+        try {
+            addCommandDefinition(lines, commandDefinitions, blockRange);
+        } catch (RuntimeException e) {
+            LogUtil.e(TAG, "Failed to parse command block", e);
+        }
+    }
+
+    private static ArrayList<String> splitLines(String sourceCode) {
+        return new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+    }
+
+    private static boolean isTextReplacementCommand(String command) {
+        return COMMAND_FIND_REPLACE.equals(command)
+                || COMMAND_FIND_REPLACE_FIRST.equals(command)
+                || COMMAND_FIND_REPLACE_ALL.equals(command);
+    }
+
+    private static String applyTextReplacementCommand(String sourceCode, String command, String reference, String input) {
+        if (reference.isEmpty()) {
+            return sourceCode;
+        }
+        if (COMMAND_FIND_REPLACE.equals(command)) {
+            return sourceCode.replace(reference, input);
+        }
+        if (COMMAND_FIND_REPLACE_FIRST.equals(command)) {
+            try {
+                return sourceCode.replaceFirst(reference, input);
+            } catch (PatternSyntaxException e) {
+                LogUtil.e(TAG, "Failed to apply replaceFirst command", e);
+                return sourceCode;
+            }
+        }
+        if (COMMAND_FIND_REPLACE_ALL.equals(command)) {
+            try {
+                return sourceCode.replaceAll(reference, input);
+            } catch (PatternSyntaxException e) {
+                LogUtil.e(TAG, "Failed to apply replaceAll command", e);
+                return sourceCode;
+            }
+        }
+        return sourceCode;
+    }
+
+    private static void addLine(ArrayList<String> lines, int lineIndex, String input) {
+        if (lineIndex < 0) {
+            lines.add(0, input);
+        } else if (lineIndex > (lines.size() - 1)) {
+            lines.add(input);
+        } else {
+            lines.add(lineIndex, input);
+        }
+    }
+
+    private static void applyReplaceCommand(ArrayList<String> lines, int index, int distance, int before, int after, String input) {
+        if (before < 0) {
+            before = 0;
+        }
+        if (after < 0) {
+            after = 0;
+        }
+        if (before == 0 && after == 0) {
+            int lineToChange = index + distance;
+            if (lineToChange < 0) {
+                lineToChange = 0;
+            }
+            if (lineToChange > (lines.size() - 1)) {
+                lineToChange = lines.size() - 1;
+            }
+            lines.set(lineToChange, input);
+        } else {
+            int lineToChange = index + distance;
+            if (lineToChange <= 0) {
+                lineToChange = 0;
+                int from = 1;
+                int to = after + 1;
+                if (to > (lines.size() - 1)) {
+                    to = lines.size() - 1;
+                }
+                lines.subList(from, to).clear();
+                lines.set(0, input);
+            } else if (lineToChange >= (lines.size() - 1)) {
+                lineToChange = lines.size() - 1;
+                int from = lineToChange - before;
+                int to = lineToChange;
+                if (from < 0) {
+                    from = 0;
+                }
+                lines.set(lineToChange, input);
+                lines.subList(from, to).clear();
+            } else {
+                int from = lineToChange + 1;
+                int to = lineToChange + after;
+                if (to > (lines.size() - 1)) {
+                    to = lines.size() - 1;
+                }
+                lines.subList(from, to).clear();
+                lines.set(lineToChange, input);
+                from = lineToChange - before;
+                to = lineToChange;
+                if (from < 0) {
+                    from = 0;
+                }
+                lines.subList(from, to).clear();
             }
         }
     }
@@ -340,145 +379,46 @@ public class CommandBlock {
     }
 
     private static String applyCollectedCommands(ArrayList<HashMap<String, Object>> commandDefinitions, String sourceCode) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         for (HashMap<String, Object> commandDefinition : commandDefinitions) {
-            String reference = getStringValue(commandDefinition, KEY_REFERENCE);
-            int distance = getNumericValue(commandDefinition, KEY_DISTANCE);
-            int after = getNumericValue(commandDefinition, KEY_AFTER);
-            int before = getNumericValue(commandDefinition, KEY_BEFORE);
-            String command = getStringValue(commandDefinition, KEY_COMMAND);
-            String input = getStringValue(commandDefinition, KEY_INPUT);
+            ArrayList<String> previousLines = new ArrayList<>(lines);
+            try {
+                String reference = getStringValue(commandDefinition, KEY_REFERENCE);
+                int distance = getNumericValue(commandDefinition, KEY_DISTANCE);
+                int after = getNumericValue(commandDefinition, KEY_AFTER);
+                int before = getNumericValue(commandDefinition, KEY_BEFORE);
+                String command = getStringValue(commandDefinition, KEY_COMMAND);
+                String input = getStringValue(commandDefinition, KEY_INPUT);
 
-            if (command.equals("find-replace")) {
-                String temp = joinLines(lines);
-                temp = temp.replace(reference, input);
-                lines = new ArrayList<>(Arrays.asList(temp.split("\n")));
-                continue;
-            }
-            if (command.equals("find-replace-first")) {
-                try {
-                    String temp = joinLines(lines);
-                    temp = temp.replaceFirst(reference, input);
-                    lines = new ArrayList<>(Arrays.asList(temp.split("\n")));
-                    continue;
-                } catch (PatternSyntaxException e) {
-                    LogUtil.e(TAG, "Failed to apply replaceFirst command", e);
+                if (reference.isEmpty()) {
                     continue;
                 }
-            }
 
-            if (command.equals("find-replace-all")) {
-                try {
-                    String temp = joinLines(lines);
-                    temp = temp.replaceAll(reference, input);
-                    lines = new ArrayList<>(Arrays.asList(temp.split("\n")));
-                    continue;
-                } catch (PatternSyntaxException e) {
-                    LogUtil.e(TAG, "Failed to apply replaceAll command", e);
+                if (isTextReplacementCommand(command)) {
+                    lines = splitLines(applyTextReplacementCommand(joinLines(lines), command, reference, input));
                     continue;
                 }
-            }
 
-            int index = getIndex(lines, reference);
-            if (index == -1) {
-                continue;
-            }
-
-
-            if (command.equals("insert")) {
-                if ((index + distance - before) < 0) {
-                    lines.add(0, input);
-                } else if ((index + distance - before) > (lines.size() - 1)) {
-                    lines.add(input);
-                } else {
-                    lines.add(index + distance - before, input);
+                int index = getIndex(lines, reference);
+                if (index == -1) {
+                    continue;
                 }
-                continue;
-            }
-            if (command.equals("add")) {
-                if ((index + distance + after + 1) < 0) {
-                    lines.add(0, input);
-                } else if ((index + distance + after + 1) > (lines.size() - 1)) {
-                    lines.add(input);
-                } else {
-                    lines.add(index + distance + after + 1, input);
+
+                if (COMMAND_INSERT.equals(command)) {
+                    addLine(lines, index + distance - before, input);
+                    continue;
                 }
-                continue;
-            }
-
-            ///old method
-        /*
-        if(command.equals("replace")){
-            boolean isZ = false;
-            int xxx = (int)(index + distance - before -1);
-            if ( xxx <=0 ){ isZ = true; xxx = 0; }
-
-            int ff = (int)(index + distance - before);
-            if ( ff <0 ){ ff = 0; }
-            int tt = (int)(index + distance + after +1);
-            if ( tt > a.size() ){ tt = a.size(); }
-            a.subList(ff , tt).clear();
-            //// fix bug
-            if (xxx > a.size()-2){
-                a.add(input);
-            } else if(isZ) {
-                a.add(0, input);
-            } else {
-                a.add((int)(xxx+1) , input);
-            } continue ;}*/
-
-            if (command.equals("replace")) {
-                if (before == 0 && after == 0) {
-                    int lineToChange = index + distance;
-                    if (lineToChange < 0) {
-                        lineToChange = 0;
-                    }
-                    if (lineToChange > (lines.size() - 1)) {
-                        lineToChange = lines.size() - 1;
-                    }
-                    lines.set(lineToChange, input);
-                } else {
-                    int lineToChange = index + distance;
-                    if (lineToChange <= 0) { // ignore backend
-                        lineToChange = 0;
-                        int from = 1;
-                        int to = after + 1;
-                        if (to > (lines.size() - 1)) {
-                            to = lines.size() - 1;
-                        }
-                        lines.subList(from, to).clear();
-                        lines.set(0, input);
-                    } else if (lineToChange >= (lines.size() - 1)) { //ignore frontend
-                        lineToChange = lines.size() - 1;
-                        int from = lineToChange - before;
-                        int to = lineToChange;
-                        if (from < 0) {
-                            from = 0;
-                        }
-                        lines.set(lineToChange, input);
-                        lines.subList(from, to).clear();
-                    } else {  //handle everything
-                        if (before < 0) {
-                            before = 0;
-                        }
-                        if (after < 0) {
-                            after = 0;
-                        }
-                        int from = lineToChange + 1;
-                        int to = lineToChange + after;
-                        if (to > (lines.size() - 1)) {
-                            to = lines.size() - 1;
-                        }
-                        lines.subList(from, to).clear();
-                        lines.set(lineToChange, input);
-                        from = lineToChange - before;
-                        to = lineToChange;
-                        if (from < 0) {
-                            from = 0;
-                        }
-                        lines.subList(from, to).clear();
-                    }
+                if (COMMAND_ADD.equals(command)) {
+                    addLine(lines, index + distance + after + 1, input);
+                    continue;
                 }
+
+                if (COMMAND_REPLACE.equals(command)) {
+                    applyReplaceCommand(lines, index, distance, before, after, input);
+                }
+            } catch (RuntimeException e) {
+                LogUtil.e(TAG, "Failed to apply collected command", e);
+                lines = previousLines;
             }
         }
 
@@ -506,22 +446,33 @@ public class CommandBlock {
     }
 
     private static String removeCommandBlocks(String sourceCode, String startMarker, String endMarker) {
-        ArrayList<String> lines = new ArrayList<>(Arrays.asList(sourceCode.split("\n")));
+        ArrayList<String> lines = splitLines(sourceCode);
         ArrayList<String> resultLines = new ArrayList<>();
-        boolean shouldKeepLine = true;
-        for (int i = 0; i < lines.size(); i++) {
-            if (shouldKeepLine) {
-                if (!lines.get(i).contains(startMarker)) {
-                    resultLines.add(lines.get(i));
+        ArrayList<String> bufferedBlockLines = new ArrayList<>();
+        boolean isInsideCommandBlock = false;
+        for (String line : lines) {
+            if (!isInsideCommandBlock) {
+                if (line.contains(startMarker)) {
+                    bufferedBlockLines.clear();
+                    bufferedBlockLines.add(line);
+                    if (!line.contains(endMarker)) {
+                        isInsideCommandBlock = true;
+                    }
+                } else {
+                    resultLines.add(line);
                 }
+                continue;
             }
 
-            if (lines.get(i).contains(startMarker)) {
-                shouldKeepLine = false;
+            bufferedBlockLines.add(line);
+            if (line.contains(endMarker)) {
+                bufferedBlockLines.clear();
+                isInsideCommandBlock = false;
             }
-            if (lines.get(i).contains(endMarker)) {
-                shouldKeepLine = true;
-            }
+        }
+
+        if (isInsideCommandBlock) {
+            resultLines.addAll(bufferedBlockLines);
         }
 
         return joinLines(resultLines);
@@ -535,9 +486,20 @@ public class CommandBlock {
         String command;
         String input = "";
 
+        if (blockRange.second - blockRange.first < 6) {
+            LogUtil.e(TAG, "Skipping malformed command block with insufficient header lines at lines "
+                    + (blockRange.first + 1) + "-" + (blockRange.second + 1));
+            return;
+        }
+
         String line = lines.get(blockRange.first + 1);
         String jsonReference = line.substring(line.indexOf(">") + 1);
         ArrayList<String> parsedReference = GSON.fromJson(jsonReference, Helper.TYPE_STRING);
+        if (parsedReference == null || parsedReference.isEmpty()) {
+            LogUtil.e(TAG, "Skipping malformed command block with empty reference at lines "
+                    + (blockRange.first + 1) + "-" + (blockRange.second + 1));
+            return;
+        }
         reference = parsedReference.get(0);
 
         line = lines.get(blockRange.first + 2);

--- a/app/src/main/java/pro/sketchware/activities/editor/command/ManageXMLCommandActivity.java
+++ b/app/src/main/java/pro/sketchware/activities/editor/command/ManageXMLCommandActivity.java
@@ -81,46 +81,49 @@ public class ManageXMLCommandActivity extends BaseAppCompatActivity {
         var projectDataManager = ProjectDataManager.getProjectDataManager(sc_id);
         projectFilePaths.initializeMetadata(projectLibraryManager, projectFileManager, projectDataManager);
         CommandBlock.clearTempCommands();
-        ArrayList<ProjectFileBean> files = new ArrayList<>(projectFileManager.getActivities());
-        files.addAll(new ArrayList<>(projectFileManager.getCustomViews()));
-
-        if (files.isEmpty()) {
-            FileUtil.writeFile(path, "[]");
-            return;
-        }
-
-        // Pre-warm BlockLoader caches to avoid race conditions during parallel execution
-        BlockLoader.getBlockFromProject(sc_id, "");
-
-        // Phase 1: Generate code for all activities in parallel (expensive step)
-        int cpus = Math.max(1, Runtime.getRuntime().availableProcessors());
-        ExecutorService pool = Executors.newFixedThreadPool(Math.min(cpus, files.size()));
         try {
-            List<CompletableFuture<String>> futures = new ArrayList<>(files.size());
-            for (ProjectFileBean file : files) {
-                futures.add(CompletableFuture.supplyAsync(() ->
-                        new ActivityCodeGenerator(projectFilePaths.buildConfig, file, projectDataManager)
-                                .generateCode(false, sc_id), pool));
+            ArrayList<ProjectFileBean> files = new ArrayList<>(projectFileManager.getActivities());
+            files.addAll(new ArrayList<>(projectFileManager.getCustomViews()));
+
+            if (files.isEmpty()) {
+                FileUtil.writeFile(path, "[]");
+                return;
             }
 
-            // Phase 2: Apply CBForXml serially (not thread-safe)
-            for (CompletableFuture<String> future : futures) {
-                try {
-                    CommandBlock.collectXmlCommandBlocks(future.get());
-                } catch (Exception e) {
-                    Log.e("ManageXMLCommand", "Code generation failed", e);
+            // Pre-warm BlockLoader caches to avoid race conditions during parallel execution
+            BlockLoader.getBlockFromProject(sc_id, "");
+
+            // Phase 1: Generate code for all activities in parallel (expensive step)
+            int cpus = Math.max(1, Runtime.getRuntime().availableProcessors());
+            ExecutorService pool = Executors.newFixedThreadPool(Math.min(cpus, files.size()));
+            try {
+                List<CompletableFuture<String>> futures = new ArrayList<>(files.size());
+                for (ProjectFileBean file : files) {
+                    futures.add(CompletableFuture.supplyAsync(() ->
+                            new ActivityCodeGenerator(projectFilePaths.buildConfig, file, projectDataManager)
+                                    .generateCode(false, sc_id, false), pool));
                 }
+
+                // Phase 2: Apply CBForXml serially (not thread-safe)
+                for (CompletableFuture<String> future : futures) {
+                    try {
+                        CommandBlock.collectXmlCommandBlocks(future.get());
+                    } catch (Exception e) {
+                        Log.e("ManageXMLCommand", "Code generation failed", e);
+                    }
+                }
+            } finally {
+                pool.shutdown();
+            }
+
+            String commandPath = SketchwarePaths.getTempCommandsPath();
+            if (FileUtil.isExistFile(commandPath)) {
+                FileUtil.copyFile(commandPath, path);
+            } else {
+                FileUtil.writeFile(path, "[]");
             }
         } finally {
-            pool.shutdown();
-        }
-
-        String commandPath = FileUtil.getExternalStorageDir().concat("/.sketchware/temp/commands");
-        if (FileUtil.isExistFile(commandPath)) {
-            FileUtil.copyFile(commandPath, path);
             CommandBlock.clearTempCommands();
-        } else {
-            FileUtil.writeFile(path, "[]");
         }
     }
 

--- a/app/src/main/java/pro/sketchware/core/ProjectFilePaths.java
+++ b/app/src/main/java/pro/sketchware/core/ProjectFilePaths.java
@@ -726,36 +726,42 @@ public class ProjectFilePaths {
             writeProjectFile(bean.srcFileName, bean.source);
         }
         if (buildConfig.isFirebaseEnabled || buildConfig.isAdMobEnabled || buildConfig.isMapUsed) {
-            ProjectLibraryBean firebaseLibrary = projectLibraryManager.getFirebaseDB();
-            XmlBuilderHelper xmlBuilder = new XmlBuilderHelper();
-            xmlBuilder.addInteger("google_play_services_version", 12451000);
-            if (buildConfig.isFirebaseEnabled) {
-                String databaseUrl;
-                String projectId;
-                String libraryData = firebaseLibrary.data;
-                if (libraryData.contains(".")) {
-                    databaseUrl = "https://" + libraryData;
-                    projectId = libraryData.trim().replaceAll(FIREBASE_DATABASE_STORAGE_LOCATION_MATCHER, "");
-                } else {
-                    databaseUrl = "https://" + libraryData + ".firebaseio.com";
-                    projectId = libraryData;
+            CommandBlock.clearTempCommands();
+            try {
+                prepareXmlCommands(projectFileManager, projectDataManger);
+                ProjectLibraryBean firebaseLibrary = projectLibraryManager.getFirebaseDB();
+                XmlBuilderHelper xmlBuilder = new XmlBuilderHelper();
+                xmlBuilder.addInteger("google_play_services_version", 12451000);
+                if (buildConfig.isFirebaseEnabled) {
+                    String databaseUrl;
+                    String projectId;
+                    String libraryData = firebaseLibrary.data;
+                    if (libraryData.contains(".")) {
+                        databaseUrl = "https://" + libraryData;
+                        projectId = libraryData.trim().replaceAll(FIREBASE_DATABASE_STORAGE_LOCATION_MATCHER, "");
+                    } else {
+                        databaseUrl = "https://" + libraryData + ".firebaseio.com";
+                        projectId = libraryData;
+                    }
+                    xmlBuilder.addString("firebase_database_url", databaseUrl, false);
+                    xmlBuilder.addString("project_id", projectId, false);
+                    xmlBuilder.addString("google_app_id", firebaseLibrary.reserved1, false);
+                    if (firebaseLibrary.reserved2 != null && !firebaseLibrary.reserved2.isEmpty()) {
+                        xmlBuilder.addString("google_api_key", firebaseLibrary.reserved2, false);
+                    }
+                    if (firebaseLibrary.reserved3 != null && !firebaseLibrary.reserved3.isEmpty()) {
+                        xmlBuilder.addString("google_storage_bucket", firebaseLibrary.reserved3, false);
+                    }
                 }
-                xmlBuilder.addString("firebase_database_url", databaseUrl, false);
-                xmlBuilder.addString("project_id", projectId, false);
-                xmlBuilder.addString("google_app_id", firebaseLibrary.reserved1, false);
-                if (firebaseLibrary.reserved2 != null && !firebaseLibrary.reserved2.isEmpty()) {
-                    xmlBuilder.addString("google_api_key", firebaseLibrary.reserved2, false);
+                if (buildConfig.isMapUsed) {
+                    xmlBuilder.addString("google_maps_key", projectLibraryManager.getGoogleMap().data, false);
                 }
-                if (firebaseLibrary.reserved3 != null && !firebaseLibrary.reserved3.isEmpty()) {
-                    xmlBuilder.addString("google_storage_bucket", firebaseLibrary.reserved3, false);
-                }
+                String filePath = "values/secrets.xml";
+                fileUtil.writeText(resDirectoryPath + File.separator + filePath,
+                        CommandBlock.applyCommands(filePath, xmlBuilder.toCode()));
+            } finally {
+                CommandBlock.clearTempCommands();
             }
-            if (buildConfig.isMapUsed) {
-                xmlBuilder.addString("google_maps_key", projectLibraryManager.getGoogleMap().data, false);
-            }
-            String filePath = "values/secrets.xml";
-            fileUtil.writeText(resDirectoryPath + File.separator + filePath,
-                    CommandBlock.applyCommands(filePath, xmlBuilder.toCode()));
         }
         generateGradleFiles();
     }
@@ -770,230 +776,236 @@ public class ProjectFilePaths {
     public ArrayList<SrcCodeBean> generateSourceCodeBeans(ProjectFileManager projectFileManager, ProjectDataStore projectDataManager, LibraryManager projectLibraryManager, BuiltInLibraryManager builtInLibraryManager) {
         generateDebugFiles(SketchApplication.getAppContext());
         CommandBlock.clearTempCommands();
-
-        String javaDir = FileUtil.getExternalStorageDir() + "/.sketchware/data/" + sc_id + "/files/java/";
-        String layoutDir = FileUtil.getExternalStorageDir() + "/.sketchware/data/" + sc_id + "/files/resource/layout/";
-        List<File> javaFiles;
-        {
-            File[] files = new File(javaDir).listFiles();
-            if (files == null) files = new File[0];
-            javaFiles = Arrays.asList(files);
-        }
-        List<File> layoutFiles;
-        {
-            File[] files = new File(layoutDir).listFiles();
-            if (files == null) files = new File[0];
-            layoutFiles = Arrays.asList(files);
-        }
-
-        // Generate Activities unless a custom version of it exists already
-        // at /Internal storage/.sketchware/data/<sc_id>/files/java/
-        ArrayList<SrcCodeBean> srcCodeBeans = new ArrayList<>();
-
-        List<ProjectFileBean> activitiesToGenerate = new ArrayList<>();
-        for (ProjectFileBean activity : projectFileManager.getActivities()) {
-            if (!javaFiles.contains(new File(javaDir + activity.getJavaName()))) {
-                activitiesToGenerate.add(activity);
+        try {
+            String javaDir = FileUtil.getExternalStorageDir() + "/.sketchware/data/" + sc_id + "/files/java/";
+            String layoutDir = FileUtil.getExternalStorageDir() + "/.sketchware/data/" + sc_id + "/files/resource/layout/";
+            List<File> javaFiles;
+            {
+                File[] files = new File(javaDir).listFiles();
+                if (files == null) files = new File[0];
+                javaFiles = Arrays.asList(files);
             }
-        }
-
-        // Code generation cache: skip regeneration if inputs haven't changed
-        File codegenCacheDir = new File(SketchApplication.getAppContext().getCacheDir(), "codegenCache/" + sc_id);
-        String cacheKey = computeCodeGenCacheKey(projectFileManager, projectDataManager, projectLibraryManager);
-        boolean cacheHit = false;
-
-        File cacheKeyFile = new File(codegenCacheDir, "cache.key");
-        if (cacheKeyFile.exists()) {
-            try {
-                String cachedKey = FileUtil.readFile(cacheKeyFile.getAbsolutePath());
-                if (cacheKey.equals(cachedKey)) {
-                    // Try to load all activities from cache
-                    boolean allCached = true;
-                    ArrayList<SrcCodeBean> cachedBeans = new ArrayList<>();
-                    for (ProjectFileBean activity : activitiesToGenerate) {
-                        File cachedFile = new File(codegenCacheDir, activity.getJavaName() + ".code");
-                        if (cachedFile.exists()) {
-                            String cachedCode = FileUtil.readFile(cachedFile.getAbsolutePath());
-                            cachedBeans.add(new SrcCodeBean(activity.getJavaName(),
-                                    ActivityCodeGenerator.applyCommands(cachedCode)));
-                        } else {
-                            allCached = false;
-                            break;
-                        }
-                    }
-                    if (allCached) {
-                        srcCodeBeans.addAll(cachedBeans);
-                        cacheHit = true;
-                    }
-                }
-            } catch (Exception e) {
-                Log.e("ProjectFilePaths", "Cache read failed", e);
+            List<File> layoutFiles;
+            {
+                File[] files = new File(layoutDir).listFiles();
+                if (files == null) files = new File[0];
+                layoutFiles = Arrays.asList(files);
             }
-        }
 
-        int threadCount = 0;
-        if (!cacheHit) {
-            // Cache miss: generate code and save to cache
-            codegenCacheDir.mkdirs();
+            // Generate Activities unless a custom version of it exists already
+            // at /Internal storage/.sketchware/data/<sc_id>/files/java/
+            ArrayList<SrcCodeBean> srcCodeBeans = new ArrayList<>();
 
-            // Pre-build shared objects once for all Activities (optimization)
-            ManageLocalLibrary sharedMll = new ManageLocalLibrary(projectDataManager.projectId);
-            HashMap<String, Map<String, Object>> sharedExtraBlocksMap = ActivityCodeGenerator.buildExtraBlocksMap(getExtraBlockData());
-            Material3LibraryManager sharedMaterialLibraryManager = new Material3LibraryManager(projectDataManager.projectId);
-
-            // Pre-warm BlockLoader caches to avoid race conditions during parallel execution
-            BlockLoader.getBlockFromProject(sc_id, "");
-
-            threadCount = activitiesToGenerate.isEmpty() ? 0
-                    : Math.min(Runtime.getRuntime().availableProcessors(), activitiesToGenerate.size());
-            if (threadCount <= 1) {
-                for (ProjectFileBean activity : activitiesToGenerate) {
-                    String phase1Code = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
-                            sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
-                            .generateCode(isAndroidStudioExport, sc_id, false);
-                    srcCodeBeans.add(new SrcCodeBean(activity.getJavaName(),
-                            ActivityCodeGenerator.applyCommands(phase1Code)));
-                    FileUtil.writeFile(new File(codegenCacheDir, activity.getJavaName() + ".code").getAbsolutePath(), phase1Code);
+            List<ProjectFileBean> activitiesToGenerate = new ArrayList<>();
+            for (ProjectFileBean activity : projectFileManager.getActivities()) {
+                if (!javaFiles.contains(new File(javaDir + activity.getJavaName()))) {
+                    activitiesToGenerate.add(activity);
                 }
-            } else {
-                ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            }
+
+            // Code generation cache: skip regeneration if inputs haven't changed
+            File codegenCacheDir = new File(SketchApplication.getAppContext().getCacheDir(), "codegenCache/" + sc_id);
+            String cacheKey = computeCodeGenCacheKey(projectFileManager, projectDataManager, projectLibraryManager);
+            boolean cacheHit = false;
+
+            File cacheKeyFile = new File(codegenCacheDir, "cache.key");
+            if (cacheKeyFile.exists()) {
                 try {
-                    List<Future<Pair<String, String>>> futures = new ArrayList<>();
-
-                    for (ProjectFileBean activity : activitiesToGenerate) {
-                        futures.add(executor.submit(() -> {
-                            String rawCode = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
-                                    sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
-                                    .generateCode(isAndroidStudioExport, sc_id, false);
-                            return new Pair<>(activity.getJavaName(), rawCode);
-                        }));
-                    }
-
-                    // Phase 2: Apply command blocks serially (CommandBlock is not thread-safe)
-                    for (int i = 0; i < futures.size(); i++) {
-                        try {
-                            Pair<String, String> result = futures.get(i).get();
-                            srcCodeBeans.add(new SrcCodeBean(result.first,
-                                    ActivityCodeGenerator.applyCommands(result.second)));
-                            FileUtil.writeFile(new File(codegenCacheDir, result.first + ".code").getAbsolutePath(), result.second);
-                        } catch (Exception e) {
-                            Log.e("ProjectFilePaths", "Parallel code generation failed, falling back to serial", e);
-                            ProjectFileBean activity = activitiesToGenerate.get(i);
-                            String phase1Code = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
-                                    sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
-                                    .generateCode(isAndroidStudioExport, sc_id, false);
-                            srcCodeBeans.add(new SrcCodeBean(activity.getJavaName(),
-                                    ActivityCodeGenerator.applyCommands(phase1Code)));
-                            FileUtil.writeFile(new File(codegenCacheDir, activity.getJavaName() + ".code").getAbsolutePath(), phase1Code);
+                    String cachedKey = FileUtil.readFile(cacheKeyFile.getAbsolutePath());
+                    if (cacheKey.equals(cachedKey)) {
+                        // Try to load all activities from cache
+                        boolean allCached = true;
+                        ArrayList<SrcCodeBean> cachedBeans = new ArrayList<>();
+                        for (ProjectFileBean activity : activitiesToGenerate) {
+                            File cachedFile = new File(codegenCacheDir, activity.getJavaName() + ".code");
+                            if (cachedFile.exists()) {
+                                String cachedCode = FileUtil.readFile(cachedFile.getAbsolutePath());
+                                cachedBeans.add(new SrcCodeBean(activity.getJavaName(),
+                                        ActivityCodeGenerator.applyCommands(cachedCode)));
+                            } else {
+                                allCached = false;
+                                break;
+                            }
+                        }
+                        if (allCached) {
+                            srcCodeBeans.addAll(cachedBeans);
+                            cacheHit = true;
                         }
                     }
-                } finally {
-                    executor.shutdownNow();
+                } catch (Exception e) {
+                    Log.e("ProjectFilePaths", "Cache read failed", e);
                 }
             }
-            // Save cache key after successful generation
-            FileUtil.writeFile(cacheKeyFile.getAbsolutePath(), cacheKey);
-        }
 
-        var path = SketchwarePaths.getDataPath(sc_id) + "/command";
-        var newXMLCommand = Boolean.parseBoolean(projectSettings.getValue(ProjectSettings.SETTING_NEW_XML_COMMAND, ProjectSettings.SETTING_GENERIC_VALUE_FALSE));
-        if (newXMLCommand && FileUtil.isExistFile(path)) {
-            FileUtil.copyFile(path, FileUtil.getExternalStorageDir().concat("/.sketchware/temp/commands"));
-        }
+            if (!cacheHit) {
+                CommandBlock.clearTempCommands();
+            }
 
-        var viewBindingBuilder = new ViewBindingBuilder(List.of(), new File("."), packageName);
+            int threadCount = 0;
+            if (!cacheHit) {
+                // Cache miss: generate code and save to cache
+                codegenCacheDir.mkdirs();
 
-        // Generate layouts unless a custom version of it exists already
-        // at /Internal storage/.sketchware/data/<sc_id>/files/resource/layout/
-        ArrayList<ProjectFileBean> regularLayouts = projectFileManager.getActivities();
-        for (ProjectFileBean layout : regularLayouts) {
-            String xmlName = layout.getXmlName();
-            LayoutGenerator layoutGenerator = new LayoutGenerator(buildConfig, layout);
-            layoutGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(xmlName)), projectDataManager.getFabView(xmlName));
-            var ogFile = new File(layoutDir + xmlName);
-            if (!layoutFiles.contains(ogFile)) {
-                srcCodeBeans.add(new SrcCodeBean(xmlName, CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString())));
+                // Pre-build shared objects once for all Activities (optimization)
+                ManageLocalLibrary sharedMll = new ManageLocalLibrary(projectDataManager.projectId);
+                HashMap<String, Map<String, Object>> sharedExtraBlocksMap = ActivityCodeGenerator.buildExtraBlocksMap(getExtraBlockData());
+                Material3LibraryManager sharedMaterialLibraryManager = new Material3LibraryManager(projectDataManager.projectId);
 
-                if (isViewBindingEnable()) {
-                    var privFile = new File(context.getCacheDir(), xmlName);
-                    FileUtil.writeFile(privFile.getAbsolutePath(), CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString()));
-                    var code = viewBindingBuilder.generateBindingForLayout(privFile);
-                    srcCodeBeans.add(new SrcCodeBean(
-                            ViewBindingBuilder.generateFileNameForLayout(xmlName.replace(".xml", "")) + ".java",
-                            CommandBlock.applyCommands(xmlName, code)
-                    ));
+                // Pre-warm BlockLoader caches to avoid race conditions during parallel execution
+                BlockLoader.getBlockFromProject(sc_id, "");
+
+                threadCount = activitiesToGenerate.isEmpty() ? 0
+                        : Math.min(Runtime.getRuntime().availableProcessors(), activitiesToGenerate.size());
+                if (threadCount <= 1) {
+                    for (ProjectFileBean activity : activitiesToGenerate) {
+                        String phase1Code = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
+                                sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
+                                .generateCode(isAndroidStudioExport, sc_id, false);
+                        srcCodeBeans.add(new SrcCodeBean(activity.getJavaName(),
+                                ActivityCodeGenerator.applyCommands(phase1Code)));
+                        FileUtil.writeFile(new File(codegenCacheDir, activity.getJavaName() + ".code").getAbsolutePath(), phase1Code);
+                    }
+                } else {
+                    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+                    try {
+                        List<Future<Pair<String, String>>> futures = new ArrayList<>();
+
+                        for (ProjectFileBean activity : activitiesToGenerate) {
+                            futures.add(executor.submit(() -> {
+                                String rawCode = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
+                                        sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
+                                        .generateCode(isAndroidStudioExport, sc_id, false);
+                                return new Pair<>(activity.getJavaName(), rawCode);
+                            }));
+                        }
+
+                        // Phase 2: Apply command blocks serially (CommandBlock is not thread-safe)
+                        for (int i = 0; i < futures.size(); i++) {
+                            try {
+                                Pair<String, String> result = futures.get(i).get();
+                                srcCodeBeans.add(new SrcCodeBean(result.first,
+                                        ActivityCodeGenerator.applyCommands(result.second)));
+                                FileUtil.writeFile(new File(codegenCacheDir, result.first + ".code").getAbsolutePath(), result.second);
+                            } catch (Exception e) {
+                                Log.e("ProjectFilePaths", "Parallel code generation failed, falling back to serial", e);
+                                ProjectFileBean activity = activitiesToGenerate.get(i);
+                                String phase1Code = new ActivityCodeGenerator(buildConfig, activity, projectDataManager,
+                                        sharedMll, projectSettings, sharedExtraBlocksMap, sharedMaterialLibraryManager)
+                                        .generateCode(isAndroidStudioExport, sc_id, false);
+                                srcCodeBeans.add(new SrcCodeBean(activity.getJavaName(),
+                                        ActivityCodeGenerator.applyCommands(phase1Code)));
+                                FileUtil.writeFile(new File(codegenCacheDir, activity.getJavaName() + ".code").getAbsolutePath(), phase1Code);
+                            }
+                        }
+                    } finally {
+                        executor.shutdownNow();
+                    }
+                }
+                // Save cache key after successful generation
+                FileUtil.writeFile(cacheKeyFile.getAbsolutePath(), cacheKey);
+            }
+
+            var path = SketchwarePaths.getDataPath(sc_id) + "/command";
+            var newXMLCommand = Boolean.parseBoolean(projectSettings.getValue(ProjectSettings.SETTING_NEW_XML_COMMAND, ProjectSettings.SETTING_GENERIC_VALUE_FALSE));
+            if (newXMLCommand && FileUtil.isExistFile(path)) {
+                FileUtil.copyFile(path, SketchwarePaths.getTempCommandsPath());
+            }
+
+            var viewBindingBuilder = new ViewBindingBuilder(List.of(), new File("."), packageName);
+
+            // Generate layouts unless a custom version of it exists already
+            // at /Internal storage/.sketchware/data/<sc_id>/files/resource/layout/
+            ArrayList<ProjectFileBean> regularLayouts = projectFileManager.getActivities();
+            for (ProjectFileBean layout : regularLayouts) {
+                String xmlName = layout.getXmlName();
+                LayoutGenerator layoutGenerator = new LayoutGenerator(buildConfig, layout);
+                layoutGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(xmlName)), projectDataManager.getFabView(xmlName));
+                var ogFile = new File(layoutDir + xmlName);
+                if (!layoutFiles.contains(ogFile)) {
+                    srcCodeBeans.add(new SrcCodeBean(xmlName, CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString())));
+
+                    if (isViewBindingEnable()) {
+                        var privFile = new File(context.getCacheDir(), xmlName);
+                        FileUtil.writeFile(privFile.getAbsolutePath(), CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString()));
+                        var code = viewBindingBuilder.generateBindingForLayout(privFile);
+                        srcCodeBeans.add(new SrcCodeBean(
+                                ViewBindingBuilder.generateFileNameForLayout(xmlName.replace(".xml", "")) + ".java",
+                                code
+                        ));
+                    }
                 }
             }
-        }
 
-        ArrayList<ProjectFileBean> customViewFiles = projectFileManager.getCustomViews();
-        for (ProjectFileBean customViewFile : customViewFiles) {
-            String xmlName = customViewFile.getXmlName();
-            LayoutGenerator layoutGenerator = new LayoutGenerator(buildConfig, customViewFile);
-            layoutGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(xmlName)));
-            var ogFile = new File(layoutDir + xmlName);
-            if (!layoutFiles.contains(ogFile)) {
-                srcCodeBeans.add(new SrcCodeBean(xmlName, CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString())));
+            ArrayList<ProjectFileBean> customViewFiles = projectFileManager.getCustomViews();
+            for (ProjectFileBean customViewFile : customViewFiles) {
+                String xmlName = customViewFile.getXmlName();
+                LayoutGenerator layoutGenerator = new LayoutGenerator(buildConfig, customViewFile);
+                layoutGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(xmlName)));
+                var ogFile = new File(layoutDir + xmlName);
+                if (!layoutFiles.contains(ogFile)) {
+                    srcCodeBeans.add(new SrcCodeBean(xmlName, CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString())));
 
-                if (isViewBindingEnable()) {
-                    var privFile = new File(context.getCacheDir(), xmlName);
-                    FileUtil.writeFile(privFile.getAbsolutePath(), CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString()));
-                    var code = viewBindingBuilder.generateBindingForLayout(privFile);
-                    srcCodeBeans.add(new SrcCodeBean(
-                            ViewBindingBuilder.generateFileNameForLayout(xmlName.replace(".xml", "")) + ".java",
-                            CommandBlock.applyCommands(xmlName, code)
-                    ));
+                    if (isViewBindingEnable()) {
+                        var privFile = new File(context.getCacheDir(), xmlName);
+                        FileUtil.writeFile(privFile.getAbsolutePath(), CommandBlock.applyCommands(xmlName, layoutGenerator.toXmlString()));
+                        var code = viewBindingBuilder.generateBindingForLayout(privFile);
+                        srcCodeBeans.add(new SrcCodeBean(
+                                ViewBindingBuilder.generateFileNameForLayout(xmlName.replace(".xml", "")) + ".java",
+                                code
+                        ));
+                    }
                 }
             }
-        }
 
-        ManifestGenerator manifestGenerator = new ManifestGenerator(buildConfig, projectFileManager.getActivities(), builtInLibraryManager);
-        manifestGenerator.setProjectFilePaths(this);
+            ManifestGenerator manifestGenerator = new ManifestGenerator(buildConfig, projectFileManager.getActivities(), builtInLibraryManager);
+            manifestGenerator.setProjectFilePaths(this);
 
-        // Make generated classes viewable
-        if (!javaFiles.contains(new File(javaDir + "SketchwareUtil.java"))) {
-            srcCodeBeans.add(new SrcCodeBean("SketchwareUtil.java",
-                    ComponentTemplates.getSketchwareUtilCode(packageName, material3LibraryManager.isMaterial3Enabled())));
-        }
-
-        if (!javaFiles.contains(new File(javaDir + "FileUtil.java"))) {
-            srcCodeBeans.add(new SrcCodeBean("FileUtil.java",
-                    ComponentTemplates.getFileUtilCode(packageName)));
-        }
-
-        if (!javaFiles.contains(new File(javaDir + "RequestNetwork.java")) && buildConfig.isHttp3Used) {
-            srcCodeBeans.add(new SrcCodeBean("RequestNetwork.java",
-                    ComponentCodeGenerator.formatCode(ComponentTemplates.getRequestNetworkCode(packageName), false)));
-        }
-
-        if (!FileUtil.isExistFile(javaDir + "RequestNetworkController.java") && buildConfig.isHttp3Used) {
-            srcCodeBeans.add(new SrcCodeBean("RequestNetworkController.java",
-                    ComponentCodeGenerator.formatCode(ComponentTemplates.getRequestNetworkControllerCode(packageName), false)));
-        }
-
-        if (!javaFiles.contains(new File(javaDir + "BluetoothConnect.java")) && buildConfig.hasPermission(BuildConfig.PERMISSION_BLUETOOTH)) {
-            srcCodeBeans.add(new SrcCodeBean("BluetoothConnect.java",
-                    ComponentCodeGenerator.formatCode(ComponentTemplates.getBluetoothConnectCode(packageName), false)));
-        }
-
-        if (!javaFiles.contains(new File(javaDir + "BluetoothController.java")) && buildConfig.hasPermission(BuildConfig.PERMISSION_BLUETOOTH)) {
-            srcCodeBeans.add(new SrcCodeBean("BluetoothController.java",
-                    ComponentCodeGenerator.formatCode(ComponentTemplates.getBluetoothControllerCode(packageName), false)));
-        }
-
-        if (buildConfig.isMapUsed) {
-            if (!javaFiles.contains(new File(javaDir + "GoogleMapController.java")) && buildConfig.isMapUsed) {
-                srcCodeBeans.add(new SrcCodeBean("GoogleMapController.java",
-                        ComponentCodeGenerator.formatCode(ComponentTemplates.getGoogleMapControllerCode(packageName), false)));
+            // Make generated classes viewable
+            if (!javaFiles.contains(new File(javaDir + "SketchwareUtil.java"))) {
+                srcCodeBeans.add(new SrcCodeBean("SketchwareUtil.java",
+                        ComponentTemplates.getSketchwareUtilCode(packageName, material3LibraryManager.isMaterial3Enabled())));
             }
-        }
 
-        srcCodeBeans.add(new SrcCodeBean("AndroidManifest.xml", CommandBlock.applyCommands("AndroidManifest.xml", manifestGenerator.generateManifest())));
-        srcCodeBeans.add(new SrcCodeBean("styles.xml", getXMLStyle()));
-        srcCodeBeans.add(new SrcCodeBean("colors.xml", getXMLColor()));
-        srcCodeBeans.add(new SrcCodeBean("strings.xml", getXMLString()));
-        CommandBlock.clearTempCommands();
-        return srcCodeBeans;
+            if (!javaFiles.contains(new File(javaDir + "FileUtil.java"))) {
+                srcCodeBeans.add(new SrcCodeBean("FileUtil.java",
+                        ComponentTemplates.getFileUtilCode(packageName)));
+            }
+
+            if (!javaFiles.contains(new File(javaDir + "RequestNetwork.java")) && buildConfig.isHttp3Used) {
+                srcCodeBeans.add(new SrcCodeBean("RequestNetwork.java",
+                        ComponentCodeGenerator.formatCode(ComponentTemplates.getRequestNetworkCode(packageName), false)));
+            }
+
+            if (!FileUtil.isExistFile(javaDir + "RequestNetworkController.java") && buildConfig.isHttp3Used) {
+                srcCodeBeans.add(new SrcCodeBean("RequestNetworkController.java",
+                        ComponentCodeGenerator.formatCode(ComponentTemplates.getRequestNetworkControllerCode(packageName), false)));
+            }
+
+            if (!javaFiles.contains(new File(javaDir + "BluetoothConnect.java")) && buildConfig.hasPermission(BuildConfig.PERMISSION_BLUETOOTH)) {
+                srcCodeBeans.add(new SrcCodeBean("BluetoothConnect.java",
+                        ComponentCodeGenerator.formatCode(ComponentTemplates.getBluetoothConnectCode(packageName), false)));
+            }
+
+            if (!javaFiles.contains(new File(javaDir + "BluetoothController.java")) && buildConfig.hasPermission(BuildConfig.PERMISSION_BLUETOOTH)) {
+                srcCodeBeans.add(new SrcCodeBean("BluetoothController.java",
+                        ComponentCodeGenerator.formatCode(ComponentTemplates.getBluetoothControllerCode(packageName), false)));
+            }
+
+            if (buildConfig.isMapUsed) {
+                if (!javaFiles.contains(new File(javaDir + "GoogleMapController.java")) && buildConfig.isMapUsed) {
+                    srcCodeBeans.add(new SrcCodeBean("GoogleMapController.java",
+                            ComponentCodeGenerator.formatCode(ComponentTemplates.getGoogleMapControllerCode(packageName), false)));
+                }
+            }
+
+            srcCodeBeans.add(new SrcCodeBean("AndroidManifest.xml", CommandBlock.applyCommands("AndroidManifest.xml", manifestGenerator.generateManifest())));
+            srcCodeBeans.add(new SrcCodeBean("styles.xml", getXMLStyle()));
+            srcCodeBeans.add(new SrcCodeBean("colors.xml", getXMLColor()));
+            srcCodeBeans.add(new SrcCodeBean("strings.xml", getXMLString()));
+            return srcCodeBeans;
+        } finally {
+            CommandBlock.clearTempCommands();
+        }
     }
 
     private boolean isViewBindingEnable() {
@@ -1008,59 +1020,73 @@ public class ProjectFilePaths {
     public String getFileSrc(String filename, ProjectFileManager projectFileManager, ProjectDataStore projectDataManager, LibraryManager projectLibraryManager) {
         initializeMetadata(projectLibraryManager, projectFileManager, projectDataManager);
         CommandBlock.clearTempCommands();
-        boolean isJavaFile = filename.endsWith(".java");
-        boolean isXmlFile = filename.endsWith(".xml");
-        boolean isManifestFile = filename.equals("AndroidManifest.xml");
-        ArrayList<ProjectFileBean> files = new ArrayList<>(projectFileManager.getActivities());
-        files.addAll(new ArrayList<>(projectFileManager.getCustomViews()));
-        if (isXmlFile) {
-            var path = SketchwarePaths.getDataPath(sc_id) + "/command";
-            var newXMLCommand = Boolean.parseBoolean(projectSettings.getValue(ProjectSettings.SETTING_NEW_XML_COMMAND, ProjectSettings.SETTING_GENERIC_VALUE_FALSE));
-            if (newXMLCommand && FileUtil.isExistFile(path)) {
-                FileUtil.copyFile(path, FileUtil.getExternalStorageDir().concat("/.sketchware/temp/commands"));
-            } else {
+        try {
+            boolean isJavaFile = filename.endsWith(".java");
+            boolean isXmlFile = filename.endsWith(".xml");
+            boolean isManifestFile = filename.equals("AndroidManifest.xml");
+            ArrayList<ProjectFileBean> files = new ArrayList<>(projectFileManager.getActivities());
+            files.addAll(new ArrayList<>(projectFileManager.getCustomViews()));
+            if (isXmlFile) {
                 /*
                  Generating every java file is necessary to make command blocks for xml work
                  */
-                for (ProjectFileBean file : files) {
-                    CommandBlock.collectXmlCommandBlocks(new ActivityCodeGenerator(buildConfig, file, projectDataManager).generateCode(isAndroidStudioExport, sc_id));
+                prepareXmlCommands(projectFileManager, projectDataManager);
+            }
+
+            switch (filename) {
+                case "strings.xml" -> {
+                    return getXMLString();
+                }
+                case "colors.xml" -> {
+                    return getXMLColor();
+                }
+                case "styles.xml" -> {
+                    return getXMLStyle();
+                }
+            }
+
+            if (isManifestFile) {
+                ProjectBuilder builder = new ProjectBuilder(SketchApplication.getAppContext(), this);
+                builder.buildBuiltInLibraryInformation();
+                ManifestGenerator manifestGenerator = new ManifestGenerator(buildConfig, projectFileManager.getActivities(), builder.getBuiltInLibraryManager());
+                manifestGenerator.setProjectFilePaths(this);
+                return CommandBlock.applyCommands("AndroidManifest.xml", manifestGenerator.generateManifest());
+            }
+
+            for (ProjectFileBean file : files) {
+                if (filename.equals(isJavaFile ? file.getJavaName() : file.getXmlName())) {
+                    if (isJavaFile) {
+                        return new ActivityCodeGenerator(buildConfig, file, projectDataManager).generateCode(isAndroidStudioExport, sc_id);
+                    } else if (isXmlFile) {
+                        LayoutGenerator xmlGenerator = new LayoutGenerator(buildConfig, file);
+                        xmlGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(filename)), projectDataManager.getFabView(filename));
+                        return CommandBlock.applyCommands(filename, xmlGenerator.toXmlString());
+                    }
+                }
+            }
+
+            return "";
+        } finally {
+            CommandBlock.clearTempCommands();
+        }
+    }
+
+    private void prepareXmlCommands(ProjectFileManager projectFileManager, ProjectDataStore projectDataManager) {
+        ArrayList<ProjectFileBean> files = new ArrayList<>(projectFileManager.getActivities());
+        files.addAll(new ArrayList<>(projectFileManager.getCustomViews()));
+        String path = SketchwarePaths.getDataPath(sc_id) + "/command";
+        boolean newXMLCommand = Boolean.parseBoolean(projectSettings.getValue(ProjectSettings.SETTING_NEW_XML_COMMAND, ProjectSettings.SETTING_GENERIC_VALUE_FALSE));
+        if (newXMLCommand && FileUtil.isExistFile(path)) {
+            FileUtil.copyFile(path, SketchwarePaths.getTempCommandsPath());
+        } else {
+            for (ProjectFileBean file : files) {
+                try {
+                    CommandBlock.collectXmlCommandBlocks(new ActivityCodeGenerator(buildConfig, file, projectDataManager).generateCode(isAndroidStudioExport, sc_id, false));
+                } catch (RuntimeException e) {
+                    Log.e("ProjectFilePaths", "Failed to prepare XML commands", e);
                 }
             }
         }
-
-        switch (filename) {
-            case "strings.xml" -> {
-                return getXMLString();
-            }
-            case "colors.xml" -> {
-                return getXMLColor();
-            }
-            case "styles.xml" -> {
-                return getXMLStyle();
-            }
-        }
-
-        if (isManifestFile) {
-            ProjectBuilder builder = new ProjectBuilder(SketchApplication.getAppContext(), this);
-            builder.buildBuiltInLibraryInformation();
-            ManifestGenerator manifestGenerator = new ManifestGenerator(buildConfig, projectFileManager.getActivities(), builder.getBuiltInLibraryManager());
-            manifestGenerator.setProjectFilePaths(this);
-            return CommandBlock.applyCommands("AndroidManifest.xml", manifestGenerator.generateManifest());
-        }
-
-        for (ProjectFileBean file : files) {
-            if (filename.equals(isJavaFile ? file.getJavaName() : file.getXmlName())) {
-                if (isJavaFile) {
-                    return new ActivityCodeGenerator(buildConfig, file, projectDataManager).generateCode(isAndroidStudioExport, sc_id);
-                } else if (isXmlFile) {
-                    LayoutGenerator xmlGenerator = new LayoutGenerator(buildConfig, file);
-                    xmlGenerator.setViews(ProjectDataStore.getSortedRootViews(projectDataManager.getViews(filename)), projectDataManager.getFabView(filename));
-                    return CommandBlock.applyCommands(filename, xmlGenerator.toXmlString());
-                }
-            }
-        }
-
-        return "";
     }
 
     public String getXMLString() {
@@ -1070,7 +1096,7 @@ public class ProjectFilePaths {
         }
         XmlBuilderHelper stringsFileBuilder = new XmlBuilderHelper();
         stringsFileBuilder.addNonTranslatableString("app_name", applicationName);
-        return CommandBlock.applyCommands("strings.xml", stringsFileBuilder.toCode());
+        return applyStoredXmlCommandsIfNeeded("strings.xml", stringsFileBuilder.toCode());
     }
 
     public String getXMLColor() {
@@ -1084,7 +1110,7 @@ public class ProjectFilePaths {
         colorsFileBuilder.addColor("colorAccent", String.format("#%06X", colorAccent & 0xffffff));
         colorsFileBuilder.addColor("colorControlHighlight", String.format("#%06X", colorControlHighlight & 0xffffff));
         colorsFileBuilder.addColor("colorControlNormal", String.format("#%06X", colorControlNormal & 0xffffff));
-        return CommandBlock.applyCommands("colors.xml", colorsFileBuilder.toCode());
+        return applyStoredXmlCommandsIfNeeded("colors.xml", colorsFileBuilder.toCode());
     }
 
     public String getXMLStyle() {
@@ -1106,7 +1132,7 @@ public class ProjectFilePaths {
             stylesFileBuilder.addStyle("AppTheme.DebugActivity", "AppTheme");
             stylesFileBuilder.addItemToStyle("AppTheme.DebugActivity", "windowActionBar", "true");
             stylesFileBuilder.addItemToStyle("AppTheme.DebugActivity", "windowNoTitle", "false");
-            return CommandBlock.applyCommands("styles.xml", stylesFileBuilder.toCode());
+            return applyStoredXmlCommandsIfNeeded("styles.xml", stylesFileBuilder.toCode());
         } else if (buildConfig.isAppCompatEnabled) {
             boolean useNewMaterialComponentsTheme = projectSettings.getValue(ProjectSettings.SETTING_ENABLE_BRIDGELESS_THEMES,
                     BuildSettings.SETTING_GENERIC_VALUE_FALSE).equals(BuildSettings.SETTING_GENERIC_VALUE_TRUE);
@@ -1132,7 +1158,7 @@ public class ProjectFilePaths {
             stylesFileBuilder.addItemToStyle("AppTheme.DebugActivity", "actionBarTheme", "@style/Widget.MaterialComponents.ActionBar.Primary");
             stylesFileBuilder.addItemToStyle("AppTheme.DebugActivity", "windowActionBar", "true");
             stylesFileBuilder.addItemToStyle("AppTheme.DebugActivity", "windowNoTitle", "false");
-            return CommandBlock.applyCommands("styles.xml", stylesFileBuilder.toCode());
+            return applyStoredXmlCommandsIfNeeded("styles.xml", stylesFileBuilder.toCode());
         } else {
             XmlBuilderHelper stylesFileBuilder = new XmlBuilderHelper();
             stylesFileBuilder.addStyle("AppTheme", "@android:style/Theme.Material.Light.DarkActionBar");
@@ -1156,7 +1182,28 @@ public class ProjectFilePaths {
             stylesFileBuilder.addStyle("NoStatusBar", "AppTheme");
             stylesFileBuilder.addItemToStyle("NoStatusBar", "android:windowFullscreen", "true");
             stylesFileBuilder.addStyle("AppTheme.DebugActivity", "AppTheme");
-            return CommandBlock.applyCommands("styles.xml", stylesFileBuilder.toCode());
+            return applyStoredXmlCommandsIfNeeded("styles.xml", stylesFileBuilder.toCode());
+        }
+    }
+
+    private String applyStoredXmlCommandsIfNeeded(String fileName, String sourceCode) {
+        String tempCommandPath = SketchwarePaths.getTempCommandsPath();
+        if (CommandBlock.hasTempCommands()) {
+            return CommandBlock.applyCommands(fileName, sourceCode);
+        }
+
+        boolean newXMLCommand = Boolean.parseBoolean(projectSettings.getValue(ProjectSettings.SETTING_NEW_XML_COMMAND, ProjectSettings.SETTING_GENERIC_VALUE_FALSE));
+        String storedCommandPath = SketchwarePaths.getDataPath(sc_id) + "/command";
+        if (!newXMLCommand || !FileUtil.isExistFile(storedCommandPath)) {
+            return CommandBlock.applyCommands(fileName, sourceCode);
+        }
+
+        CommandBlock.clearTempCommands();
+        try {
+            FileUtil.copyFile(storedCommandPath, tempCommandPath);
+            return CommandBlock.applyCommands(fileName, sourceCode);
+        } finally {
+            CommandBlock.clearTempCommands();
         }
     }
 

--- a/app/src/main/java/pro/sketchware/core/SketchwarePaths.java
+++ b/app/src/main/java/pro/sketchware/core/SketchwarePaths.java
@@ -260,10 +260,13 @@ public class SketchwarePaths {
         return getAbsolutePathOf(TEMP_SOUNDS_PATH);
     }
 
+    public static String getTempCommandsPath() {
+        return getAbsolutePathOf(".sketchware" + File.separator + "temp" + File.separator + "commands");
+    }
+
     public static String getUploadPath() {
         return getAbsolutePathOf(UPLOAD_PATH);
     }
-
 
     public static String getCustomComponent() {
         return getAbsolutePathOf(CUSTOM_COMPONENT_FILE);


### PR DESCRIPTION
## Summary

This PR continues the low-risk cleanup of [CommandBlock](cci:2://file:///c:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/blocks/CommandBlock.java:28:0-533:1) and its direct XML command call sites.

It hardens temporary command state handling, avoids premature command processing during XML command collection, and contains malformed command block failures to individual blocks instead of letting a single bad block affect later valid ones.

Closes #3

## Changes

- centralize the temp commands path with [SketchwarePaths.getTempCommandsPath()](cci:1://file:///c:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/pro/sketchware/core/SketchwarePaths.java:262:4-264:5)
- add [CommandBlock.hasTempCommands()](cci:1://file:///c:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/blocks/CommandBlock.java:70:4-72:5) so callers can check for parsed, usable temp commands instead of relying on raw file existence/content
- avoid writing empty temp command files when no XML commands were collected
- harden temp command parsing fallback so malformed temp command JSON is treated as unavailable instead of blocking XML fallback
- make `ProjectFilePaths` reuse stored XML commands only when temp commands are actually valid
- keep XML command preparation in the intended two-phase flow by generating raw activity code first and collecting XML command blocks serially
- harden [processCommandBlocks()](cci:1://file:///c:/Users/Administrator/IdeaProjects/Sketchware-Pro/app/src/main/java/mod/hilal/saif/blocks/CommandBlock.java:201:4-220:5) fallback to strip both Java and XML command markers on failure
- make malformed command block parsing more resilient by:
  - discarding unterminated blocks when a new block start is encountered
  - skipping malformed blocks with insufficient headers
  - skipping malformed blocks with empty parsed references
  - continuing to process later valid blocks

## Verification

- `.\gradlew.bat :app:compileDebugJavaWithJavac`
- `.\gradlew.bat :app:installDebug`

## Compatibility

- no existing public APIs were removed or had their signatures changed
- behavior is preserved for valid command blocks
- changes mainly affect failure-path handling for malformed command blocks or invalid temp command state, with safer degradation